### PR TITLE
chore: add appup.src

### DIFF
--- a/src/epgsql.appup.src
+++ b/src/epgsql.appup.src
@@ -1,0 +1,13 @@
+%%-*-: erlang -*-
+{"4.6.0",
+ [
+  %% We have to restart the application due to a lots of changes
+  %% between 4.[4-5].0 with 4.6.0
+  {<<"4\\.[4-5]\\\.0">>, [{restart_application, epgsql}]},
+  {<<".*">>, []}
+ ],
+ [
+  {<<"4\\.[4-5]\\\.0">>, [{restart_application, epgsql}]},
+  {<<".*">>, []}
+ ]
+}.


### PR DESCRIPTION
In the emqx:v4.3.15, we have upgrade the epgsql from 4.4.0 to 4.6.0 to fix some bugs (see: https://github.com/emqx/emqx/pull/8001). However the epgsql doesn't have `appup.src` file for our hot-upgrading.

In this PR, we have to restart the epgsql  application if upgrading from 4.[4-5].0 to 4.6.0, and restart the high level application/module (i.e emqx_auth_pgsql, emqx_module_auth_pgsql, emqx_backend_pgsql, emqx_backend_pgsql_actions)