### PR TITLE
fix(vsn): ensure version is release-handler-safe

### DIFF
--- a/src/epgsql.app.src
+++ b/src/epgsql.app.src
@@ -1,6 +1,6 @@
 {application, epgsql,
  [{description, "PostgreSQL Client"},
-  {vsn, "4.7.0-emqx-1"},
+  {vsn, "4.7.0.1"},
   {modules, []},
   {registered, []},
   {applications, [kernel,

--- a/src/epgsql.appup.src
+++ b/src/epgsql.appup.src
@@ -1,5 +1,5 @@
 %% -*- mode: erlang -*-
-{"4.7.0-emqx-1",
+{"4.7.0.1",
   [
     {<<"4\\.6\\.[0-9]">>, [
       {load_module, epgsql, brutal_purge, soft_purge, []},


### PR DESCRIPTION
The reasoning is this version format is more friendlier to the release handler because Erlang/OTP team uses [similar format](https://www.erlang.org/doc/system_principles/versions.html#version-scheme).

---

[EMQX-8562](https://emqx.atlassian.net/browse/EMQX-8562)