### PR TITLE
chore: improve error context

### DIFF
--- a/src/commands/epgsql_cmd_prepared_query2.erl
+++ b/src/commands/epgsql_cmd_prepared_query2.erl
@@ -66,8 +66,8 @@ zip(Name, Types, Params) ->
             error(#{cause => "prepared_data_types_and_column_count_mismatch",
                     name => Name,
                     types => Types,
-                    types_count => length(Types),
-                    values_count => length(Params)
+                    type_count => length(Types),
+                    column_count => length(Params)
                    })
     end.
 


### PR DESCRIPTION
Instead of crashing `lists:zip` with a `function_clause`.

~~The root cause of the crash is still unknown, maybe a missed update of prepared statement after the EMQX action is changed.~~
The root cause was due to prepared statement name clash, but this change should nontheless provide better hint in case similar issue happens again due to another reason. 